### PR TITLE
Deallocation issue

### DIFF
--- a/ASBPlayerScrubbing/ASBPlayerScrubbing.m
+++ b/ASBPlayerScrubbing/ASBPlayerScrubbing.m
@@ -346,4 +346,9 @@
         [self playerTimeChanged];
     }
 }
+
+#pragma mark - KVO deallocation
+- (void) dealloc {
+    [self.player.currentItem removeObserver: self forKeyPath: @"duration"];
+}
 @end

--- a/ASBPlayerScrubbing/ASBPlayerScrubbing.m
+++ b/ASBPlayerScrubbing/ASBPlayerScrubbing.m
@@ -349,6 +349,11 @@
 
 #pragma mark - KVO deallocation
 - (void) dealloc {
-    [self.player.currentItem removeObserver: self forKeyPath: @"duration"];
+    @try {
+        [self.player.currentItem removeObserver: self forKeyPath: @"duration"];
+    }
+    @catch(NSException *exception) {
+        NSLog(@"exception: %@", exception.description);
+    }
 }
 @end


### PR DESCRIPTION
When the ASBPlayerScrubbing is opened without an internet connection active and then the view controller is dismissed, it crashes because there is a KVO deallocation issue (an observer for the "duration" key path remains active).